### PR TITLE
fix: suppress API request size

### DIFF
--- a/src/docker_tags/api_request_executor.zig
+++ b/src/docker_tags/api_request_executor.zig
@@ -43,8 +43,11 @@ pub const ApiRequestExecutor = struct {
             try image_url_parts.write("library/");
         }
         try image_url_parts.write(self.image);
-
-        return try std.fmt.allocPrint(allocator, fmt, .{ image_url_parts.string(), self.initial_page, self.page_size });
+        return try std.fmt.allocPrint(allocator, fmt, .{
+            image_url_parts.string(),
+            self.initial_page,
+            @min(self.page_size, self.limit),
+        });
     }
 
     pub fn execute(self: *ApiRequestExecutor) ![]model.ImageTagInfo {


### PR DESCRIPTION
The normal display count is currently 30; suppressing the page size query on Docker Hub API requests rather than getting the default max of 100 will reduce response time.

The build run measurement in `hyperfine` shows that the current build takes about 700 ms, while the modified build takes 500 ms.

before:
````
/app # hyperfine '. /zig-out/bin/docker-tags node'
  Time (mean ± σ): 760.0 ms ± 16.8 ms [User: 30.0 ms, System: 3.7 ms].
  Range (min ... max): 743.2 ms ... 799.7 ms 10 runs
````

after:
````
/app # hyperfine './zig-out/bin/docker-tags node'
Benchmark 1: ./zig-out/bin/docker-tags node
  Time (mean ± σ):     575.1 ms ±  11.0 ms    [User: 19.9 ms, System: 3.4 ms]
  Range (min … max):   559.1 ms … 588.3 ms    10 runs
````