### PR TITLE
feat: Added subcommands compatible with docker cli plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ node   hydrogen-bullseye  amd64 / arm / arm64                    351.03 MB  2025
 ...
 ```
 
+## with Docker CLI
+
+It can be used as a docker cli plugin (v0.1.2~). That is, this tool can also be used as a subcommand of `docker`.
+
+For example:
+
+```bash
+docker tags ubuntu -d
+```
+
+To use it as a plugin, place the `docker-tags` binary in the following location:
+
+- `~/.docker/cli-plugins`
+
 ## env
 
 - It is built for Windows, Linux x86_64, and MacOS aarch64.

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     // Currently, the version is set from the main file.
     // It will be possible to set the meta value directly in build.zon from 0.14.0 onwards...
     const build_options = b.addOptions();
-    build_options.addOption([]const u8, "version", "0.1.1");
+    build_options.addOption([]const u8, "version", "0.1.2");
     build_options.addOption([]const u8, "author", "shimarisu_121");
     build_options.addOption([]const u8, "app_name", "docker-tags");
     // build_options.addOption([]const u8, "version", @import("build.zig.zon").version);

--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) void {
     // It will be possible to set the meta value directly in build.zon from 0.14.0 onwards...
     const build_options = b.addOptions();
     build_options.addOption([]const u8, "version", "0.1.1");
+    build_options.addOption([]const u8, "author", "shimarisu_121");
     build_options.addOption([]const u8, "app_name", "docker-tags");
     // build_options.addOption([]const u8, "version", @import("build.zig.zon").version);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
-    .version = "0.1.1",
+    .version = "0.1.2",
 
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything

--- a/src/cmd/cmd.zig
+++ b/src/cmd/cmd.zig
@@ -1,1 +1,2 @@
 pub const root = @import("./root.zig");
+pub const plugin_meta = @import("./plugin_meta.zig");

--- a/src/cmd/plugin_meta.zig
+++ b/src/cmd/plugin_meta.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+const zul = @import("zul");
+
+const DockerCliPluginMeta = struct {
+    SchemaVersion: []const u8 = "0.1.0",
+    Vendor: []const u8,
+    Version: []const u8,
+    ShortDescription: []const u8,
+};
+
+const Data = struct {
+    vendor: []const u8,
+    version: []const u8,
+    description: []const u8,
+};
+
+pub fn run(allocator: std.mem.Allocator, data: Data) !void {
+    _ = allocator;
+
+    const meta = DockerCliPluginMeta{
+        .Vendor = data.vendor,
+        .Version = data.version,
+        .ShortDescription = data.description,
+    };
+
+    const stdout = std.io.getStdOut();
+    try std.json.stringify(meta, .{
+        .whitespace = .indent_2,
+    }, stdout.writer());
+    _ = try stdout.writer().write("\n");
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,6 +7,10 @@ const cmd = @import("./cmd/cmd.zig");
 
 const APP_VERSION = build_options.version;
 const APP_NAME = build_options.app_name;
+const AUTHOER = build_options.author;
+const DESCRIPTION = "Search for image tags from DockerHub";
+
+const DOCKER_CLI_PLUGIN_METADATA_SUBCOMMAND = "docker-cli-plugin-metadata";
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -46,19 +50,27 @@ pub fn main() !void {
 
     // --help
     if (res.args.help != 0) {
-        const description =
+        const head_fmt =
             \\ Usage: {s} [options] <IMAGE>...
             \\
-            \\ Description: Search for image tags from DockerHub
+            \\ Description: {s}
             \\
         ;
-        std.debug.print(description ++ "\n", .{APP_NAME});
+        std.debug.print(head_fmt ++ "\n", .{ APP_NAME, DESCRIPTION });
         return clap.help(std.io.getStdErr().writer(), clap.Help, &params, .{});
     }
     // --version
     if (res.args.version != 0) {
         std.debug.print("{s} {s}\n", .{ APP_NAME, APP_VERSION });
         return;
+    }
+
+    if (res.positionals.len > 0 and std.mem.eql(u8, res.positionals[0], DOCKER_CLI_PLUGIN_METADATA_SUBCOMMAND)) {
+        return cmd.plugin_meta.run(allocator, .{
+            .version = APP_VERSION,
+            .vendor = AUTHOER,
+            .description = DESCRIPTION,
+        });
     }
 
     // set options


### PR DESCRIPTION
This PR will support the Docker CLI.

The `docker-cli-plugin-metadata` subcommand is implemented and can be used as a plugin.

The version will be updated to `v0.1.2` and the documentation will be updated accordingly.